### PR TITLE
fix: adjust workflows for linting issues

### DIFF
--- a/workflow-templates/command-l10n-update.yml
+++ b/workflow-templates/command-l10n-update.yml
@@ -10,6 +10,8 @@ name: Command L10n Update
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: read
 
 jobs:
   init:
@@ -47,9 +49,11 @@ jobs:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
           ref: ${{ needs.init.outputs.head_ref }}
+          # Needed to push changes
+          persist-credentials: true
+          token: ${{ secrets.COMMAND_BOT_PAT }}
 
       - name: Setup git
         run: |

--- a/workflow-templates/command-playwright-update.yml
+++ b/workflow-templates/command-playwright-update.yml
@@ -15,6 +15,8 @@ name: Command update Playwright snapshots
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: read
 
 jobs:
   init:
@@ -52,9 +54,11 @@ jobs:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
           ref: ${{ needs.init.outputs.head_ref }}
+          # To push the changes
+          persist-credentials: true
+          token: ${{ secrets.COMMAND_BOT_PAT }}
 
       - name: Setup git
         run: |

--- a/workflow-templates/cypress.yml
+++ b/workflow-templates/cypress.yml
@@ -68,7 +68,7 @@ jobs:
           TESTING=true npm run build --if-present
 
       - name: Save context
-        uses: buildjet/cache/save@v4
+        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Restore context
-        uses: buildjet/cache/restore@v4
+        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
         with:
           fail-on-cache-miss: true
           key: cypress-context-${{ github.run_id }}


### PR DESCRIPTION
* Resolves #16 

```
/tmp/uv-x86_64-unknown-linux-gnu/uvx zizmor --min-severity medium workflow-templates/*.yml
 INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
 INFO zizmor: skipping ref-confusion: can't run without a GitHub API token
 INFO zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed workflow-templates/block-unconventional-commits.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/command-l10n-update.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/command-playwright-update.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/cypress.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/dependabot-approve-merge.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/documentation.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/fixup.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/lint-eslint.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/lint-stylelint.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/lint-typescript.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/node-test.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/node.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/npm-audit-fix.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/npm-publish.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/playwright.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/renovate-approve-merge.yml
 INFO audit: zizmor: 🌈 completed workflow-templates/reuse.yml
No findings to report. Good job! (9 ignored, 6 suppressed)
```