### PR TITLE
feat(npm-publish): publish stable versions under different tag

### DIFF
--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -19,10 +19,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-
     name: Build and publish to npm
-    env:
-      RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || 'latest' }}
 
     steps:
       - name: Checkout
@@ -42,9 +39,24 @@ jobs:
           npm ci
           npm run build --if-present
 
+      - name: Fetch latest tag
+        id: latest-tag
+        run: |
+          TAG=$(gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json isLatest,tagName \
+            --jq 'map(select(.isLatest == true))[].tagName' \
+            -R ${{ github.repository }})
+          echo "Latest tag is $TAG"
+          echo "LATEST_TAG=$TAG" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           npm publish --tag $RELEASE_GROUP
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || ((steps.latest-tag.outputs.LATEST_TAG != github.event.release.tag_name) && 'stable' || 'latest') }}


### PR DESCRIPTION
* See also https://github.com/orgs/community/discussions/64736

For libraries we sometimes publish multiple versions, like v1 and v2, in this case releases of v1 should not be published under the `latest` tag to prevent wrong recommendations for latest versions by dependency management tools.
So this checks:
- Released tag is a RC / beta / alpha -> `next` tag
- Released tag is not the "latest version" on github -> `stable` tag
- Otherwise released tag is the latest version and not a pre-release -> `latest` tag