### PR TITLE
fix(command-*): `reaction-type` was renamed to `reactions`

### DIFF
--- a/workflow-templates/command-l10n-update.yml
+++ b/workflow-templates/command-l10n-update.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           repository: ${{ github.event.repository.full_name }}
           comment-id: ${{ github.event.comment.id }}
-          reaction-type: "+1"
+          reactions: '+1'
 
       - name: Parse command
         uses: skjnldsv/parse-command-comment@5c955203c52424151e6d0e58fb9de8a9f6a605a1 # v3.1.0

--- a/workflow-templates/command-playwright-update.yml
+++ b/workflow-templates/command-playwright-update.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           repository: ${{ github.event.repository.full_name }}
           comment-id: ${{ github.event.comment.id }}
-          reaction-type: "+1"
+          reactions: '+1'
 
       - name: Parse command
         uses: skjnldsv/parse-command-comment@5c955203c52424151e6d0e58fb9de8a9f6a605a1 # v3.1.0


### PR DESCRIPTION
Noticed this recently on the nextcloud-vue repo.