### PR TITLE
chore(lint-typescript): adjust for library usage

### DIFF
--- a/workflow-templates/lint-typescript.yml
+++ b/workflow-templates/lint-typescript.yml
@@ -1,6 +1,6 @@
 # This workflow is provided via the organization template repository
 #
-# https://github.com/nextcloud/.github
+# https://github.com/nextcloud-libraries/.github
 # https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
 #
 # SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
@@ -24,34 +24,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-
-    outputs:
-      src: ${{ steps.changes.outputs.src}}
-
-    steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        continue-on-error: true
-        with:
-          filters: |
-            src:
-              - '.github/workflows/lint-typescript.yml'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'tsconfig.json'
-              - '**.ts'
-              - '**.vue'
-
   test:
     runs-on: ubuntu-latest
-
-    needs: changes
-    if: needs.changes.outputs.src != 'false'
+    name: Lint Typescript
 
     steps:
       - name: Checkout
@@ -59,42 +34,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
-        with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: 'package.json'
 
       - name: Install dependencies
         env:
           CYPRESS_INSTALL_BINARY: 0
-        run: |
-          npm ci
+        run: npm ci
 
       - name: Check types
         run: |
           npm run --if-present check-types
           npm run --if-present ts:check
-
-  summary:
-    permissions:
-      contents: none
-    runs-on: ubuntu-latest
-    needs: [changes, test]
-
-    if: always()
-
-    name: typescript-summary
-
-    steps:
-      - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.test.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
Make it consistent with the other workflows for libraries:
- use node version file for setup
- no changes step needed
- thus also no summary needed