### PR TITLE
fix(node-tests): for libraries org a codecov token is required

### DIFF
--- a/workflow-templates/node-test.yml
+++ b/workflow-templates/node-test.yml
@@ -56,3 +56,5 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           files: ./coverage/lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It is provided by the organization already, but all repos must use it (or generate their own). It prevents external pushes (forks) of potential sensitive data.