### PR TITLE
Revert "chore!: remove `npm-publish` as libraries should be put into the `nextcloud-libraries` org"

### DIFF
--- a/workflow-templates/npm-publish.properties.json
+++ b/workflow-templates/npm-publish.properties.json
@@ -1,0 +1,11 @@
+{
+  "name": "Publish to npm",
+  "description": "Build and publish package to npm on tagged releases.",
+  "iconName": "octicon package",
+  "categories": [
+    "JavaScript"
+  ],
+  "filePatterns": [
+      "^package.json$"
+  ]
+}

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -1,0 +1,85 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Build and publish to npm
+    environment: npm-publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Read package.json
+        uses: nextcloud/parse-package-engines-action@122ae05d4257008180a514e1ddeb0c1b9d094bdd # v0.1.0
+        id: versions
+
+<<<<<<< HEAD
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+=======
+      - name: Set up node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+>>>>>>> 62f358a (fix: drop npm token publishing and use trusted publisher)
+        with:
+          node-version: ${{ steps.versions.outputs.node-version }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Set up npm
+        run: npm i -g 'npm@${{ steps.versions.outputs.package-manager-version }}'
+
+      - name: Check tag matches package.json
+        run: |
+          VERSION=$(node -p -e "require('./package.json').version")
+          GH_VERSION=$(echo "$GH_VERSION" | sed s,\^v,,)
+          if [ "$VERSION" != "$GH_VERSION" ]; then
+            echo "$VERSION does not match $GH_VERSION"
+            exit 1;
+          fi;
+        env:
+          GH_VERSION: ${{ github.event.release.tag_name }}
+
+      - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+        run: |
+          npm ci --ignore-scripts
+          npm run build --if-present
+
+      - name: Fetch latest tag
+        id: latest-tag
+        run: |
+          TAG=$(gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json isLatest,tagName \
+            --jq 'map(select(.isLatest == true))[].tagName' \
+            -R ${{ github.repository }})
+          echo "Latest tag is $TAG"
+          echo "LATEST_TAG=$TAG" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Publish
+        run: |
+          npm publish --tag $RELEASE_GROUP
+        env:
+          RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || ((steps.latest-tag.outputs.LATEST_TAG != github.event.release.tag_name) && 'stable' || 'latest') }}

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -1,6 +1,6 @@
 # This workflow is provided via the organization template repository
 #
-# https://github.com/nextcloud/.github
+# https://github.com/nextcloud-libraries/.github
 # https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
 #
 # SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
@@ -29,16 +29,11 @@ jobs:
           persist-credentials: false
 
       - name: Read package.json
-        uses: nextcloud/parse-package-engines-action@122ae05d4257008180a514e1ddeb0c1b9d094bdd # v0.1.0
+        uses: nextcloud-libraries/parse-package-engines-action@122ae05d4257008180a514e1ddeb0c1b9d094bdd # v0.1.0
         id: versions
 
-<<<<<<< HEAD
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-=======
       - name: Set up node
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
->>>>>>> 62f358a (fix: drop npm token publishing and use trusted publisher)
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ steps.versions.outputs.node-version }}
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
This reverts commit 250d8c451b9c9240e4eb4707478cac57fb89d187.
