### PR TITLE
fix(dependabot-approve-merge): missing ENVs from conflict resolution

### DIFF
--- a/workflow-templates/dependabot-approve-merge.yml
+++ b/workflow-templates/dependabot-approve-merge.yml
@@ -26,6 +26,13 @@ jobs:
   auto-approve-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
+    env:
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 2.0.0
+      ALLOW_MAJOR: false
+      # env variable for maintainers: 'true' allows to auto-merge 1.0.2 -> 1.1.0
+      ALLOW_MINOR: true
+      # env variable for maintainers: RegExp string to ignore some dependencies from auto-approve and auto-merge
+      IGNORE_PATTERN: ''
     permissions:
       # for auto-approve step to work
       pull-requests: write


### PR DESCRIPTION
- Action fails for non-patch updates
- Regression from https://github.com/nextcloud-libraries/.github/pull/169
- Conflict resolution lost a part of the changes changes in 
  - https://github.com/nextcloud-libraries/.github/pull/169/changes/2e54c726a0b057a1e23e54b1aa7aa55b4f3fb835

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
